### PR TITLE
Dollar strings with many decimal places

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function(num) {
   // convert the number to a string
   num = num.toString();
 
-  var numReg = /^\$?(?!0\.00)\d{1,3}(,\d{3})*(\.\d\d)?$/;
+  var numReg = /^\$?\d{1,3}(,\d{3})*(\.\d*)?$/;
 
   // check for numbers and regex patterns
   if ( ( !isNaN(+num) ) ||

--- a/test/is-money-tests.js
+++ b/test/is-money-tests.js
@@ -58,5 +58,14 @@ exports.isMoney = {
     test.equal(isMoney('3,672.38'), true, 'commas and decimals should return true');
     test.equal(isMoney(',45$.00'), false, 'incorrectly formatted $ strings should return false');
     test.done();
-  }
+  },
+  "Dollar strings vs. Floats":function(test) {
+    test.expect(4);
+    test.equal(isMoney("$3."),isMoney(3.),"Dollar strings that would otherwise parse as floats show return true");
+    test.equal(isMoney("$3.1"),isMoney(3.1),"Dollar strings that would otherwise parse as floats show return true");
+    test.equal(isMoney("$3.14"),isMoney(3.14),"Dollar strings that would otherwise parse as floats show return true");
+    test.equal(isMoney("$3.141"),isMoney(3.141),"Dollar strings that would otherwise parse as floats show return true");
+    test.done();
+  } 
+
 };


### PR DESCRIPTION
The current version fails on dollar strings with more than two decimal places. This may be by design (_eg_, you only use this on dollar strings when you are being very particular about their format), but I think it could lead to confusing situations since it accepts **any** number. Meaning 3.141 would be accepted, "3.141" would be accepted, but "$3.141" would be rejected. This doesn't seem quite right to me.

A common scenario where you find this level of precision is gas prices (today's national average is $3.513, I paid $3.759 this morning).

Allowing such precision required/allowed the removal of the special-casing of "$0.00"  (would formerly reject "$0.001" but accept "0.001" and 0.001, the same strange behavior as above). Again, if this is expected behavior, feel free to ignore this PR.
